### PR TITLE
Proposal: how we could describe an individual test case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/rmes.Rproj
+++ b/rmes.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/tests/testCase1.json
+++ b/tests/testCase1.json
@@ -1,0 +1,16 @@
+{
+  "type": "TestCase",
+  "uuid": "4fa03a8d-2e39-4866-9cd3-69b77bd78a6b",
+  "testName": "t test produces calibrated p values",
+  "keywords": ["t-test", "p value", "statistics"],
+  "description": "This test checks that the p values produced by stats::t.test do not deviate substantially from the expected uniform distribution.",
+  "references:" "",
+  "code": "set.seed(42)\nm <- 100\nfor (n in c(5, 50, 500)) {\n# repeatedly sample data under null and record p value\nres <- numeric(m)\nfor (i in 1:m) {\nres[i] <- t.test(rnorm(n))$p.value\n}\n# expect non significant result\nexpect_true(\nks.test(res, 'punif')$p.value > 0.05\n)\n}",
+  "output": "",
+  "environment": {
+    "container": "rocker/tidyverse:4.3.1",
+    "runtime": "singularity",
+    "runtimeVersion": "3.8",
+    "renvLockfile": ""
+  }
+}


### PR DESCRIPTION
This PR explores how we could describe an individual test case. The idea would be to then aggregate multiple such tests to assess a function / package and build human-readable documentation. 

Besides test cases, we could also define formats for sharing bugs or discrepancies from other implementaitons -> different topic though.

Would be cool to see whether we can run these atomic test cases in GH actions.