### PR TITLE
Proposal: CSA: Robust Scripted Test example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+[0725/102132.113:ERROR:registration_protocol_win.cc(107)] CreateFile: The system cannot find the file specified. (0x2)

--- a/rmes.Rproj
+++ b/rmes.Rproj
@@ -1,0 +1,13 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX

--- a/tests/robustScriptedTesting.json
+++ b/tests/robustScriptedTesting.json
@@ -1,0 +1,40 @@
+{
+    "type": "AssuranceActivity",
+    "activity": "Scripted Testing: Robust",
+    "testObjective": {
+      "type": "TestObjective",
+      "uuid": "6cde1b0f-3e41-4878-8cd5-79c87be88a7d",
+      "objective": "Verify that p values produced by stats::t.test are uniformly distributed",
+      "keywords": ["t-test", "p value", "statistics"],
+      "testCases": [
+        {
+          "type": "TestCase",
+          "uuid": "4fa03a8d-2e39-4866-9cd3-69b77bd78a6b",
+          "testName": "t test produces calibrated p values",
+          "description": "This test checks that the p values produced by stats::t.test do not deviate substantially from the expected uniform distribution.",
+          "code": "set.seed(42)\nm <- 100\nfor (n in c(5, 50, 500)) {\n# repeatedly sample data under null and record p value\nres <- numeric(m)\nfor (i in 1:m) {\nres[i] <- t.test(rnorm(n))$p.value\n}\n# expect non significant result\nexpect_true(\nks.test(res, 'punif')$p.value > 0.05\n)\n}",
+          "result": "pass",
+          "environment": {
+            "container": "rocker/tidyverse:4.3.1",
+            "runtime": "singularity",
+            "runtimeVersion": "3.8",
+            "renvLockfile": ""
+          }
+        },
+        {
+          "type": "TestCase",
+          "uuid": "5bce1a9d-3e40-4877-8cd4-79c87be88a7c",
+          "testName": "Another t test example",
+          "description": "This is another test case related to the same test objective.",
+          "code": "Your test case code here",
+          "result": "fail",
+          "environment": {
+            "container": "rocker/tidyverse:4.3.1",
+            "runtime": "singularity",
+            "runtimeVersion": "3.8",
+            "renvLockfile": ""
+          }
+        }
+      ]
+    }
+  }

--- a/tests/testCase1.json
+++ b/tests/testCase1.json
@@ -1,0 +1,16 @@
+{
+  "type": "TestCase",
+  "uuid": "4fa03a8d-2e39-4866-9cd3-69b77bd78a6b",
+  "testName": "t test produces calibrated p values",
+  "keywords": ["t-test", "p value", "statistics"],
+  "description": "This test checks that the p values produced by stats::t.test do not deviate substantially from the expected uniform distribution.",
+  "references:" "",
+  "code": "set.seed(42)\nm <- 100\nfor (n in c(5, 50, 500)) {\n# repeatedly sample data under null and record p value\nres <- numeric(m)\nfor (i in 1:m) {\nres[i] <- t.test(rnorm(n))$p.value\n}\n# expect non significant result\nexpect_true(\nks.test(res, 'punif')$p.value > 0.05\n)\n}",
+  "output": "",
+  "environment": {
+    "container": "rocker/tidyverse:4.3.1",
+    "runtime": "singularity",
+    "runtimeVersion": "3.8",
+    "renvLockfile": ""
+  }
+}


### PR DESCRIPTION
Proposal: CSA: Robust Scripted Test example

Derived from Kevin's original proposal, but tried to hamonize terms and the general approach with Computer Software Assurance Draft Guideline.
More specifically, this limits itself for now on the assurance activity -> "Scripted testing: robust", which is the most closest to the tradional "GAMP way" of testing.

- Intends to match proposed terminology in CSA
- Moves test cases into a hierarchical structure : Assurance Activity -> Test Objective -> Test Case
- Excluded "references" information for now. This would propbably need to come dependent on whether we want everything to go into one json file or split: e.g. One JSON for specification, intended use risk determination and a second JSON for the testing/verfication.
